### PR TITLE
Add sphinx code copybutton support

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -40,6 +40,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'sphinx.ext.viewcode',
               'sphinx.ext.githubpages',
+              'sphinx_copybutton',
               'nbsphinx',
               'sphinx_rtd_theme',
               'IPython.sphinxext.ipython_console_highlighting']
@@ -81,7 +82,7 @@ release = '0.6.1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/source/install/installation.rst
+++ b/doc/source/install/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-For end users, the easiest way to install *PyLag* is using *Conda*. This will install *PyLag* and all its dependencies into a clean environment and make it available to use. Developers who wish to work with the source code directly should clone *PyLag's* git repository from `GitHub <https://github.com/jimc101/PyLag>`_ and install it manually. Both use cases are described below.
+For end users, the easiest way to install *PyLag* is using *Conda*. This will install *PyLag* and all its dependencies into a clean environment and make it available to use. Developers who wish to work with the source code directly should clone the `repository from GitHub <https://github.com/pmlmodelling/pylag>`_ and install it manually. Both use cases are described below.
 
 .. note::
         *PyLag* has been developed and tested within a UNIX/Linux environment, and the following instructions assume the user is working in a similar environment.
@@ -17,76 +17,91 @@ First `install miniconda3 <https://conda.io/projects/conda/en/latest/user-guide/
 
 .. code-block:: bash
 
-    $ source /opt/miniconda/miniconda3/bin/activate
-    $ conda update conda
-    $ conda config --prepend channels conda-forge
-    $ conda config --prepend channels JimClark
+    source /opt/miniconda/miniconda3/bin/activate
+    conda update conda
+    conda config --prepend channels conda-forge
+    conda config --prepend channels JimClark
 
 The above code assumes *miniconda3* was installed into the directory ``/opt/miniconda``, once the appropriate write permissions have been set. The default behaviour is to install *miniconda3* into your home directory. This is, of course, also fine. The *prepend* flag ensures the two new channels are added to the top of the priority list, meaning all packages will be drawn from either the *JimClark* or *conda-forge* channels.
 
-With *miniconda3* installed and configured, create a new environment in which to install *PyLag* using the following commands:
+With *miniconda3* installed and configured, create a new environment in which to install *PyLag* and activate it using the following commands:
 
 .. code-block:: bash
 
-    $ conda create -n pylag python=3.9
-    $ conda activate pylag
+    conda create -n pylag python=3.9
+    conda activate pylag
 
-Finally, install *PyLag*:
+Conda will automatically prepend ``(pylag) $`` to the prompt, indicating you are now working in the new *pylag* environment. Finally, install *PyLag*:
 
 .. code-block:: bash
 
-    (pylag) $ conda install -n pylag -c JimClark pylag
+    conda install -n pylag -c JimClark pylag
 
 To test that *PyLag* has been correctly installed, type:
 
 .. code-block:: bash
 
-    (pylag) $ python -c "import pylag"
+    python -c "import pylag"
 
 which should exit without error.
 
-.. _developers:
+Building the docs
+-----------------
 
+To build PyLag's documentation, a number of extra dependencies are required. These are not packaged with *PyLag* by default in order to keep the base installation slim and easier to manage. If you would like to build the documentation, the extra dependencies can be installed using *conda* or *pip*. The following commands use conda to install all the extra dependencies in the conda environment already created:
+
+.. code-block:: bash
+
+   conda install -n pylag sphinx nbsphinx sphinx_rtd_theme sphinxcontrib-napoleon sphinx-copybutton \
+                 jupyter jupyter_client ipykernel seapy cmocean matplotlib shapely cartopy
+
+.. code-block:: bash
+
+   conda install -c JimClark -n pylag PyQT-fit
+
+If you haven't added the JimClark channel you will need to do this before installing PyQT-fit.
+
+.. _developers:
 
 Building from source
 --------------------
 
-Developers who wish to work with the source code directly should first clone *PyLag's* git repository from `GitHub <https://github.com/pmlmodelling/pylag>`_. You can clone the repository using the following commands:
+Developers who wish to work with the source code directly should first clone *PyLag's* git repository from `Github <https://github.com/pmlmodelling/pylag>`_. You can clone the repository using the following commands:
 
 .. code-block:: bash
 
-    $ mkdir -p $HOME/code/git/PyLag && cd $HOME/code/git/PyLag
-    $ git clone https://github.com/pmlmodelling/pylag.git
+    mkdir -p $HOME/code/git/PyLag && cd $HOME/code/git/PyLag
+    git clone https://github.com/pmlmodelling/pylag.git
 
 The cleanest and safest way of installing *PyLag's* dependencies is using *Conda*. One approach is to install *PyLag* using *Conda*, as described above, before then running pip install in the PyLag code directory:
 
 .. code-block:: bash
 
-    (pylag) $ cd $HOME/code/git/PyLag/pylag
-    (pylag) $ pip install .
+    cd $HOME/code/git/PyLag/pylag
+    pip install .
 
-Alternatively, PyLag can also been built using *Conda*. Following steps similar to those described above, we can configure a new *Conda* environment so:
+Alternatively, PyLag can also be built using *Conda*. Following steps similar to those described above, we can configure a new *Conda* environment so:
 
 .. code-block:: bash
 
-    $ source /opt/miniconda/miniconda3/bin/activate
-    $ conda config --prepend channels conda-forge
-    $ conda install conda-build conda-verify
+    source /opt/miniconda/miniconda3/bin/activate
+    conda config --prepend channels conda-forge
+    conda install conda-build conda-verify
 
 The new step here is the installation of conda-build and conda-verify. Note we don't add the JimClark channel in order to avoid conda installing pylag from Anaconda cloud. Next, create a new environment as above:
 
 .. code-block:: bash
 
-    $ conda create -n pylag python=3.9
-    $ conda activate pylag
+    conda create -n pylag python=3.9
+    conda activate pylag
 
 And finally, in the PyLag source code directory, build and install *PyLag*.
 
 .. code-block:: bash
 
-    (pylag) $ cd $HOME/code/git/PyLag/PyLag
-    (pylag) $ conda build . --numpy 1.20
-    (pylag) $ conda install -n pylag --use-local pylag
+    cd $HOME/code/git/PyLag/PyLag
+    conda build . --numpy 1.20
+    conda install -n pylag --use-local pylag
 
 Occasionally, when building *PyLag* this way, users have hit upon clashes with locally installed packages. To get around this problem, you may find it useful to add the following aliases to your bashrc file, which you can use to activate and deactivate *Conda*:
 
@@ -104,34 +119,22 @@ In principle, there are several other ways *PyLag* can be installed. For example
 
 .. code-block:: bash
 
-   $ sudo dnf install -y openmpi openmpi-devel python3-openmpi
+   sudo dnf install -y openmpi openmpi-devel python3-openmpi
 
 On my machine, *openmpi* is enabled using the module command, which correctly sets environment paths to the *openmpi* MPI libraries and header files:
 
 .. code-block:: bash
 
-   $ module load mpi/openmpi-x86_64
+   module load mpi/openmpi-x86_64
 
 If running the above command fails with the system saying it is unable to find the *module* command, first use your package manager (e.g. *dnf*) to  ensure that the *environment-modules* package is installed. After installing it, you will need to open a new terminal. If it is still not found, try running:
 
 .. code-block:: bash
 
-    $ source /etc/profile.d/modules.sh
+    source /etc/profile.d/modules.sh
 
 first. If this fixes the problem, you can add the above command to your *.bashrc* file.
 
 .. note::
     The use of *sudo* -- which would allow *PyLag* to be installed at the system level -- is strongly discouraged.
 
-Building the docs
------------------
-
-To build PyLag's documentation, a number of extra dependencies are required. These are not packaged with *PyLag* by default in order to keep the base installation slim and easier to manage. If you would like to build the documentation, the extra dependencies can be installed using *conda* or *pip*. The following commands use conda to install all the extra dependencies in the conda environment already created:
-
-.. code-block:: bash
-
-   (pylag) $ conda install -n pylag sphinx nbsphinx sphinx_rtd_theme sphinxcontrib-napoleon jupyter \
-                 jupyter_client ipykernel seapy cmocean matplotlib shapely cartopy
-   (pylag) $ conda install -c JimClark -n pylag PyQT-fit
-
-If you haven't added the JimClark channel you will need to do this before installing PyQT-fit.


### PR DESCRIPTION
Add sphinx copybutton extension which allows users to easily copy code blocks from the online docs. Includes edits to the installation instructions so that code blocks can be copied without the need for extra formatting.

Fixes #74