### PR TITLE
Add start time and time step check

### DIFF
--- a/pylag/exceptions.py
+++ b/pylag/exceptions.py
@@ -15,6 +15,10 @@ class PyLagRuntimeError(PyLagException):
     pass
 
 
+class PyLagValueError(PyLagException):
+    pass
+
+
 class PyLagTypeError(PyLagException):
     pass
 


### PR DESCRIPTION
Introduce a check which ensures the user's start time and time step selections yield an integer number of time steps between the start time and the points in time when input data are defined.

Fixes #78 