### PR TITLE
Include finer control over simulation outputs

### DIFF
--- a/pylag/model.pyx
+++ b/pylag/model.pyx
@@ -591,8 +591,9 @@ cdef class OPTModel:
             diags[var_name] = np.empty(self._n_particles, dtype)
 
         # Number of boundary encounters
-        diags['land_boundary_encounters'] = np.empty(self._n_particles,
-            dtype=variable_library.get_integer_type(self.precision))
+        dtype = variable_library.get_data_type('land_boundary_encounters',
+                                               self.precision)
+        diags['land_boundary_encounters'] = np.empty(self._n_particles, dtype)
 
         # Environmental variables
         for var_name in self.environmental_variables:

--- a/pylag/model.pyx
+++ b/pylag/model.pyx
@@ -601,12 +601,11 @@ cdef class OPTModel:
 
         # Bio model variables
         if self.use_bio_model:
-            diags['is_alive'] = np.empty(self._n_particles,
-                dtype=variable_library.get_integer_type(self.precision))
+            dtype = variable_library.get_data_type('age', self.precision)
+            diags['age'] = np.empty(self._n_particles, dtype)
 
-            diags['age'] = np.empty(self._n_particles,
-                dtype=variable_library.get_real_type(self.precision))
-
+            dtype = variable_library.get_data_type('is_alive', self.precision)
+            diags['is_alive'] = np.empty(self._n_particles, dtype)
 
         # Fill the diagnostic arrays with data
         # ------------------------------------

--- a/pylag/model.pyx
+++ b/pylag/model.pyx
@@ -590,11 +590,12 @@ cdef class OPTModel:
             diags[var_name] = np.empty(self._n_particles, dtype)
 
         # Bio model variables
-        diags['is_alive'] = np.empty(self._n_particles,
-            dtype=variable_library.get_integer_type(self.precision))
+        if self.use_bio_model:
+            diags['is_alive'] = np.empty(self._n_particles,
+                dtype=variable_library.get_integer_type(self.precision))
 
-        diags['age'] = np.empty(self._n_particles,
-            dtype=variable_library.get_real_type(self.precision))
+            diags['age'] = np.empty(self._n_particles,
+                dtype=variable_library.get_real_type(self.precision))
 
 
         # Fill the diagnostic arrays with data
@@ -649,8 +650,9 @@ cdef class OPTModel:
                 diags[var_name][i] = var
 
             # Bio model variables
-            diags['age'][i] = particle_smart_ptr.age / seconds_per_day
-            diags['is_alive'][i] = particle_smart_ptr.is_alive
+            if self.use_bio_model:
+                diags['age'][i] = particle_smart_ptr.age / seconds_per_day
+                diags['is_alive'][i] = particle_smart_ptr.is_alive
 
         return diags
 

--- a/pylag/model.pyx
+++ b/pylag/model.pyx
@@ -581,9 +581,9 @@ cdef class OPTModel:
                 dtype=variable_library.get_integer_type(self.precision))
 
         # Status variables
-        for var_name in ['status', 'in_domain', 'is_beached']:
-            diags[var_name] = np.empty(self._n_particles,
-                dtype=variable_library.get_integer_type(self.precision))
+        for var_name in ['error_status', 'in_domain', 'is_beached']:
+            dtype = variable_library.get_data_type(var_name, self.precision)
+            diags[var_name] = np.empty(self._n_particles, dtype)
 
         # Extra grid variables
         for var_name in self.extra_grid_variables:
@@ -629,7 +629,7 @@ cdef class OPTModel:
             # Status variables
             diags['is_beached'][i] = particle_smart_ptr.is_beached
             diags['in_domain'][i] = particle_smart_ptr.in_domain
-            diags['status'][i] = particle_smart_ptr.status
+            diags['error_status'][i] = particle_smart_ptr.status
 
             # Extra grid variables
             if 'h' in self.extra_grid_variables:

--- a/pylag/model.pyx
+++ b/pylag/model.pyx
@@ -11,6 +11,7 @@ API is exposed in Python with accompanying documentation.
 include "constants.pxi"
 
 import logging
+import numpy as np
 
 try:
     import configparser
@@ -22,8 +23,8 @@ from pylag.data_types_python import DTYPE_INT, DTYPE_FLOAT
 from pylag.data_types_cython cimport DTYPE_INT_t, DTYPE_FLOAT_t
 
 # Error flagging
-from pylag.data_types_python import INT_INVALID, FLOAT_INVALID
-from pylag.variable_library import get_invalid_value
+from pylag.data_types_python import INT_INVALID
+from pylag import variable_library
 
 from pylag.numerics import get_num_method, get_global_time_step
 from pylag.settling import get_settling_velocity_calculator
@@ -71,6 +72,7 @@ cdef class OPTModel:
     cdef vector[Particle*] particle_ptrs
     
     # Seed particle data (as read from file)
+    cdef DTYPE_INT_t _n_particles
     cdef DTYPE_INT_t[:] _group_ids
     cdef DTYPE_FLOAT_t[:] _x1_positions
     cdef DTYPE_FLOAT_t[:] _x2_positions
@@ -82,6 +84,9 @@ cdef class OPTModel:
     # Include a biological model?
     cdef bint use_bio_model
     cdef BioModel bio_model
+
+    # Data precision, used when constructing diagnostic variable arrays
+    cdef object precision
 
     def __init__(self, config, data_reader):
         # Initialise config
@@ -141,6 +146,22 @@ cdef class OPTModel:
 
         if self.use_bio_model:
             self.bio_model = BioModel(config)
+
+        # Initialise n_particles to zero as the seed has not been created yet
+        self._n_particles = 0
+
+        # Set precision for diagnostic variables
+        try:
+            precision = self.config.get("OUTPUT", "precision")
+        except (configparser.NoSectionError, configparser.NoOptionError) as e:
+            precision = "single"
+
+        if precision == "single":
+            self.precision = 's'
+        elif precision == "double":
+            self.precision = 'd'
+        else:
+            raise PyLagValueError(f'Unknown precision flag `{precision}')
 
     def set_particle_data(self, group_ids, x1_positions, x2_positions,
                           x3_positions):
@@ -438,6 +459,9 @@ cdef class OPTModel:
             raise PyLagRuntimeError(f'All seed particles lie outside of '
                                     f'the model domain!')
 
+        # Save the total number of particles
+        self._n_particles = len(self.particle_seed_smart_ptrs)
+
         if self.config.get('GENERAL', 'log_level') == 'DEBUG':
             logger = logging.getLogger(__name__)
             logger.info(f'{particles_in_domain} of '
@@ -527,63 +551,106 @@ cdef class OPTModel:
             xmin = 0.0
             ymin = 0.0
 
-        # Initialise lists
-        diags = {'x1': [], 'x2': [], 'x3': [], 'h': [], 'zeta': [], 'is_beached': [],
-                 'in_domain': [], 'status': [], 'age': [], 'is_alive': [],
-                 'land_boundary_encounters': []}
+        # Initialise diagnostic variable arrays
+        # -------------------------------------
+        diags = {}
 
-        # Initialise host data
+        # x1, x2, x3
+        for var_name in ['x1', 'x2', 'x3']:
+            # Get the variable name which is specific to the coordinate system
+            _var_name = variable_library.get_coordinate_variable_name(
+                self.coordinate_system, var_name)
+
+            # Add to the diagnostics dictionary
+            diags[var_name] = np.empty(self._n_particles,
+                dtype=variable_library.get_data_type(_var_name, self.precision))
+
+        # Host elements
         for grid_name in self.get_grid_names():
-            diags['host_{}'.format(grid_name)] = []
+            diags[f'host_{grid_name}'] = np.empty(self._n_particles,
+                dtype=variable_library.get_integer_type(self.precision))
 
-        # Initialise env var lists
+        # Status variables
+        for var_name in ['status', 'in_domain', 'is_beached']:
+            diags[var_name] = np.empty(self._n_particles,
+                dtype=variable_library.get_integer_type(self.precision))
+
+        # Grid diagnostic vars
+        for var_name in ['h', 'zeta']:
+            dtype = variable_library.get_data_type(var_name, self.precision)
+            diags[var_name] = np.empty(self._n_particles, dtype)
+
+        # Number of boundary encounters
+        diags['land_boundary_encounters'] = np.empty(self._n_particles,
+            dtype=variable_library.get_integer_type(self.precision))
+
+        # Environmental variables
         for var_name in self.environmental_variables:
-            diags[var_name] = []
+            dtype = variable_library.get_data_type(var_name, self.precision)
+            diags[var_name] = np.empty(self._n_particles, dtype)
 
-        for particle_smart_ptr in self.particle_smart_ptrs:
+        # Bio model variables
+        diags['is_alive'] = np.empty(self._n_particles,
+            dtype=variable_library.get_integer_type(self.precision))
+
+        diags['age'] = np.empty(self._n_particles,
+            dtype=variable_library.get_real_type(self.precision))
+
+
+        # Fill the diagnostic arrays with data
+        # ------------------------------------
+        for i, particle_smart_ptr in enumerate(self.particle_smart_ptrs):
 
             # Particle location data
             if self.coordinate_system == "cartesian":
-                diags['x1'].append(particle_smart_ptr.x1 + xmin)
-                diags['x2'].append(particle_smart_ptr.x2 + ymin)
+                diags['x1'][i] = particle_smart_ptr.x1 + xmin
+                diags['x2'][i] = particle_smart_ptr.x2 + ymin
             elif self.coordinate_system == "geographic":
-                diags['x1'].append(particle_smart_ptr.x1 * radians_to_deg)
-                diags['x2'].append(particle_smart_ptr.x2 * radians_to_deg)
+                diags['x1'][i] = particle_smart_ptr.x1 * radians_to_deg
+                diags['x2'][i] = particle_smart_ptr.x2 * radians_to_deg
 
-            diags['x3'].append(particle_smart_ptr.x3)
+            diags['x3'][i] = particle_smart_ptr.x3
 
             # Grid specific host element data
             host_elements = particle_smart_ptr.get_all_host_horizontal_elems()
             for grid_name, host in host_elements.items():
-                diags['host_{}'.format(grid_name)].append(host)
+                diags[f'host_{grid_name}'][i] = host
 
-            # Particle state data
-            diags['is_beached'].append(particle_smart_ptr.is_beached)
-            diags['in_domain'].append(particle_smart_ptr.in_domain)
-            diags['status'].append(particle_smart_ptr.status)
-            diags['age'].append(particle_smart_ptr.age / seconds_per_day)
-            diags['is_alive'].append(particle_smart_ptr.is_alive)
-            diags['land_boundary_encounters'].append(
-                particle_smart_ptr.land_boundary_encounters)
+            # Status variables
+            diags['is_beached'][i] = particle_smart_ptr.is_beached
+            diags['in_domain'][i] = particle_smart_ptr.in_domain
+            diags['status'][i] = particle_smart_ptr.status
 
-            # Grid variables
+            # Grid diagnostic vars
             if particle_smart_ptr.in_domain:
-                h = self.data_reader.get_zmin(time, particle_smart_ptr.get_ptr())
-                zeta = self.data_reader.get_zmax(time, particle_smart_ptr.get_ptr())
+                h = self.data_reader.get_zmin(time,
+                                              particle_smart_ptr.get_ptr())
+                zeta = self.data_reader.get_zmax(time,
+                                                 particle_smart_ptr.get_ptr())
             else:
-                h = get_invalid_value('h')
-                zeta = get_invalid_value('zeta')
-            diags['h'].append(h)
-            diags['zeta'].append(zeta)
+                h = variable_library.get_invalid_value(diags['h'].dtype)
+                zeta = variable_library.get_invalid_value(diags['zeta'].dtype)
+            diags['h'][i] = h
+            diags['zeta'][i] = zeta
+
+            # Number of boundary encounters
+            diags['land_boundary_encounters'][i] = \
+                particle_smart_ptr.land_boundary_encounters
 
             # Environmental variables
             for var_name in self.environmental_variables:
                 if particle_smart_ptr.in_domain:
                     var = self.data_reader.get_environmental_variable(var_name,
                             time, particle_smart_ptr.get_ptr())
-                    diags[var_name].append(var)
                 else:
-                    diags[var_name].append(get_invalid_value(var_name))
+                    var = variable_library.get_invalid_value(
+                        diags[var_name].dtype)
+
+                diags[var_name][i] = var
+
+            # Bio model variables
+            diags['age'][i] = particle_smart_ptr.age / seconds_per_day
+            diags['is_alive'][i] = particle_smart_ptr.is_alive
 
         return diags
 

--- a/pylag/netcdf_logger.py
+++ b/pylag/netcdf_logger.py
@@ -255,11 +255,13 @@ class NetCDFLogger(object):
             self._age.invalid = \
                     f"{variable_library.get_invalid_value(data_type)}"
 
+            data_type = variable_library.get_data_type('is_alive',
+                                                       self._precision)
             self._is_alive = self._ncfile.createVariable('is_alive',
-                    variable_library.get_integer_type(self._precision),
-                    ('time', 'particles',), **self._ncopts)
-            self._is_alive.units = 'None'
-            self._is_alive.long_name = 'Is alive flag (1 - yes; 0 - no)'
+                    data_type, ('time', 'particles',), **self._ncopts)
+            self._is_alive.units = variable_library.get_units('is_alive')
+            self._is_alive.long_name = \
+                    variable_library.get_long_name('is_alive')
 
     def write_group_ids(self, group_ids):
         """ Write particle group IDs to file

--- a/pylag/netcdf_logger.py
+++ b/pylag/netcdf_logger.py
@@ -227,13 +227,15 @@ class NetCDFLogger(object):
                     f'{variable_library.get_invalid_value(data_type)}'
 
         # Add number of land boundary encounters
+        data_type = variable_library.get_data_type('land_boundary_encounters',
+                                                   self._precision)
         self._land_boundary_encounters = self._ncfile.createVariable(
-                'land_boundary_encounters',
-                variable_library.get_integer_type(self._precision),
+                'land_boundary_encounters', data_type,
                 ('time', 'particles',), **self._ncopts)
-        self._land_boundary_encounters.units = 'None'
+        self._land_boundary_encounters.units = \
+            variable_library.get_units('land_boundary_encounters')
         self._land_boundary_encounters.long_name = \
-            'Number of land boundary encounters'
+            variable_library.get_long_name('land_boundary_encounters')
 
         # Add environmental variables
         for var_name in self.environmental_variables:

--- a/pylag/netcdf_logger.py
+++ b/pylag/netcdf_logger.py
@@ -187,22 +187,26 @@ class NetCDFLogger(object):
             self._host_vars[grid_name].invalid = f"{INT_INVALID}"
         
         # Add status variables
-        self._status = self._ncfile.createVariable('status',
-                variable_library.get_integer_type(self._precision),
+        data_type = variable_library.get_data_type('error_status',
+                                                   self._precision)
+        self._status = self._ncfile.createVariable('error_status', data_type,
                 ('time', 'particles',), **self._ncopts)
-        self._status.units = 'None'
-        self._status.long_name = 'Status flag (1 - error state; 0 - ok)'
+        self._status.units = variable_library.get_units('error_status')
+        self._status.long_name = variable_library.get_long_name('error_status')
 
-        self._in_domain = self._ncfile.createVariable('in_domain',
-                variable_library.get_integer_type(self._precision),
+        data_type = variable_library.get_data_type('in_domain', self._precision)
+        self._in_domain = self._ncfile.createVariable('in_domain', data_type,
                 ('time', 'particles',), **self._ncopts)
-        self._in_domain.units = 'None'
-        self._in_domain.long_name = 'In domain flag (1 - yes; 0 - no)'
+        self._in_domain.units = variable_library.get_units('in_domain')
+        self._in_domain.long_name = variable_library.get_long_name('in_domain')
 
-        self._is_beached = self._ncfile.createVariable('is_beached',
-                variable_library.get_integer_type(self._precision),
+        data_type = variable_library.get_data_type('is_beached',
+                                                   self._precision)
+        self._is_beached = self._ncfile.createVariable('is_beached', data_type,
                 ('time', 'particles',), **self._ncopts)
-        self._is_beached.long_name = 'Is beached'
+        self._is_beached.units = variable_library.get_units('is_beached')
+        self._is_beached.long_name = \
+                variable_library.get_long_name('is_beached')
 
         # Extra grid variables
         if 'h' in self.extra_grid_variables:
@@ -305,7 +309,7 @@ class NetCDFLogger(object):
         self._x3[tidx, :] = particle_data['x3']
         self._is_beached[tidx, :] = particle_data['is_beached']
         self._in_domain[tidx, :] = particle_data['in_domain']
-        self._status[tidx, :] = particle_data['status']
+        self._status[tidx, :] = particle_data['error_status']
         self._land_boundary_encounters[tidx, :] = \
             particle_data['land_boundary_encounters']
 

--- a/pylag/variable_library.py
+++ b/pylag/variable_library.py
@@ -247,9 +247,19 @@ _variable_long_names['zeta'] = 'Sea surface elevation'
 
 # Status variables
 # ---------------
+
+# Bio model variables
+# -------------------
+
+# Particle age
 _variable_data_types['age'] = 'REAL'
 _variable_units['age'] = 'days (d)'
 _variable_long_names['age'] = 'Particle age'
+
+# Alive/dead status
+_variable_data_types['is_alive'] = 'INT'
+_variable_units['is_alive'] = 'None'
+_variable_long_names['is_alive'] = 'Is alive flag (1 - yes; 0 - no)'
 
 
 # Environmental variables

--- a/pylag/variable_library.py
+++ b/pylag/variable_library.py
@@ -244,6 +244,11 @@ _variable_data_types['zeta'] = 'REAL'
 _variable_units['zeta'] = 'meters (m)'
 _variable_long_names['zeta'] = 'Sea surface elevation'
 
+# Number of land boundary encounters
+_variable_data_types['land_boundary_encounters'] = 'INT'
+_variable_units['land_boundary_encounters'] = 'None'
+_variable_long_names['land_boundary_encounters'] = \
+        'Number of land boundary encounters'
 
 # Status variables
 # ---------------

--- a/pylag/variable_library.py
+++ b/pylag/variable_library.py
@@ -247,6 +247,17 @@ _variable_long_names['zeta'] = 'Sea surface elevation'
 
 # Status variables
 # ---------------
+_variable_data_types['error_status'] = 'INT'
+_variable_units['error_status'] = 'None'
+_variable_long_names['error_status'] = 'Status flag (1 - error state; 0 - ok)'
+
+_variable_data_types['in_domain'] = 'INT'
+_variable_units['in_domain'] = 'None'
+_variable_long_names['in_domain'] = 'In domain flag (1 - yes; 0 - no)'
+
+_variable_data_types['is_beached'] = 'INT'
+_variable_units['is_beached'] = 'None'
+_variable_long_names['is_beached'] = 'Is beached (1 - yes; 0 - no)'
 
 # Bio model variables
 # -------------------

--- a/pylag/variable_library.py
+++ b/pylag/variable_library.py
@@ -9,13 +9,15 @@ It includes maps for different types of input data, which map
 PyLag names (e.g. "temperature") to those used in different types
 of input data (e.g. "temp" in FVCOM).
 """
+import numpy as np
+
 from pylag.data_types_python import DTYPE_INT, DTYPE_FLOAT
 from pylag.data_types_python import INT_INVALID, FLOAT_INVALID
 
 from pylag.exceptions import PyLagValueError
 
 
-def get_data_type(var_name):
+def get_data_type(var_name, precision='s'):
     """ Get variable data type
 
     Parameters
@@ -23,13 +25,75 @@ def get_data_type(var_name):
     var_name : str
         The variable name
 
+    precision : str
+        Pass in `s` for single or `d` for double precision. Optional,
+        default: `s`.
+
     Returns
     -------
         : Python data type
         The variable data type
-
     """
-    return _variable_data_types[var_name]
+    data_type_str = _variable_data_types[var_name]
+
+    if data_type_str not in ['INT', 'REAL']:
+        raise PyLagValueError(f'Unsupported data type `{data_type_str} for '
+                              f'variable {var_name}.')
+
+    if precision == 's':
+        if data_type_str == 'INT':
+            return np.int32
+        return np.float32
+    elif precision == 'd':
+        if data_type_str == 'INT':
+            return np.int64
+        return np.float64
+    else:
+        raise PyLagValueError(f'Unknown precision flag `{precision}')
+
+
+def get_integer_type(precision="s"):
+    """ Return intger data type of the specified precision
+
+    Parameters
+    ----------
+    precision : str
+        Pass in `s` for single or `d` for double precision. Optional,
+        default: `s`.
+
+    Returns
+    -------
+        : Python data type
+        The variable data type
+    """
+    if precision == "s":
+        return np.int32
+    elif precision == "d":
+        return np.int64
+    else:
+        raise PyLagValueError(f'Unknown precision flag `{precision}')
+
+
+def get_real_type(precision="s"):
+    """ Return real data type of the specified precision
+
+    Parameters
+    ----------
+    precision : str
+        Pass in `s` for single or `d` for double precision. Optional,
+        default: `s`.
+
+    Returns
+    -------
+        : Python data type
+        The variable data type
+    """
+    if precision == "s":
+        return np.int32
+    elif precision == "d":
+        return np.int64
+    else:
+        raise PyLagValueError(f'Unknown precision flag `{precision}')
 
 
 def get_units(var_name):
@@ -66,13 +130,13 @@ def get_long_name(var_name):
     return _variable_long_names[var_name]
 
 
-def get_invalid_value(var_name):
+def get_invalid_value(dtype):
     """ Get value used for invalid entries
 
     Parameters
     ----------
-    var_name : str
-        The variable's name
+    dtype : np.dtype
+        The data type.
 
     Returns
     -------
@@ -80,7 +144,10 @@ def get_invalid_value(var_name):
          Value of invalid values
 
     """
-    return _variable_invalid_values[var_name]
+    if np.issubdtype(dtype, np.integer):
+        return INT_INVALID
+
+    return FLOAT_INVALID
 
 
 def get_coordinate_variable_name(coordinate_system, variable_name):
@@ -113,11 +180,10 @@ def get_coordinate_variable_name(coordinate_system, variable_name):
 _variable_data_types = {}
 _variable_units = {}
 _variable_long_names = {}
-_variable_invalid_values = {}
 
 
 # Particle group ID
-_variable_data_types['group_id'] = DTYPE_INT
+_variable_data_types['group_id'] = 'INT'
 _variable_units['group_id'] = 'NA'
 _variable_long_names['group_id'] = 'Particle group ID'
 
@@ -128,17 +194,17 @@ cartesian_coordinate_variable_names = {'x1': 'x',
                                        'x3': 'z'}
 
 # Particle x-position
-_variable_data_types['x'] = DTYPE_FLOAT
+_variable_data_types['x'] = 'REAL'
 _variable_units['x'] = 'm'
 _variable_long_names['x'] = 'x'
 
 # Particle y-position
-_variable_data_types['y'] = DTYPE_FLOAT
+_variable_data_types['y'] = 'REAL'
 _variable_units['y'] = 'm'
 _variable_long_names['y'] = 'y'
 
 # Particle z-position
-_variable_data_types['z'] = DTYPE_FLOAT
+_variable_data_types['z'] = 'REAL'
 _variable_units['z'] = 'm'
 _variable_long_names['z'] = 'z'
 
@@ -150,17 +216,17 @@ geographic_coordinate_variable_names = {'x1': 'longitude',
                                         'x3': 'depth'}
 
 # Particle longitude
-_variable_data_types['longitude'] = DTYPE_FLOAT
+_variable_data_types['longitude'] = 'REAL'
 _variable_units['longitude'] = 'degrees_east'
 _variable_long_names['longitude'] = 'longitude'
 
 # Particle latitude
-_variable_data_types['latitude'] = DTYPE_FLOAT
+_variable_data_types['latitude'] = 'REAL'
 _variable_units['latitude'] = 'degrees_north'
 _variable_long_names['latitude'] = 'latitude'
 
 # Particle z-position
-_variable_data_types['depth'] = DTYPE_FLOAT
+_variable_data_types['depth'] = 'REAL'
 _variable_units['depth'] = 'm'
 _variable_long_names['depth'] = 'depth'
 
@@ -169,46 +235,40 @@ _variable_long_names['depth'] = 'depth'
 # --------------------
 
 # h
-_variable_data_types['h'] = DTYPE_FLOAT
+_variable_data_types['h'] = 'REAL'
 _variable_units['h'] = 'meters (m)'
 _variable_long_names['h'] = 'Water depth'
-_variable_invalid_values['h'] = FLOAT_INVALID
 
 # zeta
-_variable_data_types['zeta'] = DTYPE_FLOAT
+_variable_data_types['zeta'] = 'REAL'
 _variable_units['zeta'] = 'meters (m)'
 _variable_long_names['zeta'] = 'Sea surface elevation'
-_variable_invalid_values['zeta'] = FLOAT_INVALID
 
 
 # Status variables
 # ---------------
-_variable_data_types['age'] = DTYPE_FLOAT
+_variable_data_types['age'] = 'REAL'
 _variable_units['age'] = 'days (d)'
 _variable_long_names['age'] = 'Particle age'
-_variable_invalid_values['age'] = FLOAT_INVALID
 
 
 # Environmental variables
 # -----------------------
 
 # thetao
-_variable_data_types['thetao'] = DTYPE_FLOAT
+_variable_data_types['thetao'] = 'REAL'
 _variable_units['thetao'] = 'degC'
 _variable_long_names['thetao'] = 'Sea Water Potential Temperature'
-_variable_invalid_values['thetao'] = FLOAT_INVALID
 
 # so
-_variable_data_types['so'] = DTYPE_FLOAT
+_variable_data_types['so'] = 'REAL'
 _variable_units['so'] = 'psu'
 _variable_long_names['so'] = 'Sea Water Salinity'
-_variable_invalid_values['so'] = FLOAT_INVALID
 
 # rsdo
-_variable_data_types['rsdo'] = DTYPE_FLOAT
+_variable_data_types['rsdo'] = 'REAL'
 _variable_units['rsdo'] = 'W m-2'
 _variable_long_names['rsdo'] = 'Downwelling Shortwave Radiation in Sea Water '
-_variable_invalid_values['rsdo'] = FLOAT_INVALID
 
 # Standard name mappings
 standard_variable_names = {'thetao': 'thetao', 'so': 'so'}
@@ -221,6 +281,8 @@ gotm_variable_names = {'thetao': 'temp', 'so': 'salt', 'rsdo': 'rad'}
 
 
 __all__ = ['get_data_type',
+           'get_integer_type',
+           'get_real_type',
            'get_units',
            'get_long_name',
            'get_invalid_value',


### PR DESCRIPTION
Fixes #101
Fixes #77

Include finer control over simulation outputs my making the saving of several variables optional, with the choice made via the run configuration file. Further, this updates allows users to select whether outputs are saved to file with single or double precision, with the former leading to a significant reduction in the fsize of output files.